### PR TITLE
Null check participant before sending receipt

### DIFF
--- a/lib/Socket/messages-recv.js
+++ b/lib/Socket/messages-recv.js
@@ -322,14 +322,16 @@ const makeMessagesRecvSocket = (config) => {
                 status > WAProto_1.proto.WebMessageInfo.WebMessageInfoStatus.DELIVERY_ACK ||
                     !isNodeFromMe)) {
                 if ((0, WABinary_1.isJidGroup)(remoteJid)) {
-                    const updateKey = status === WAProto_1.proto.WebMessageInfo.WebMessageInfoStatus.DELIVERY_ACK ? 'receiptTimestamp' : 'readTimestamp';
-                    ev.emit('message-receipt.update', ids.map(id => ({
-                        key: { ...key, id },
-                        receipt: {
-                            userJid: (0, WABinary_1.jidNormalizedUser)(attrs.participant),
-                            [updateKey]: +attrs.t
-                        }
-                    })));
+                    if (attrs.participant) {
+                        const updateKey = status === WAProto_1.proto.WebMessageInfo.WebMessageInfoStatus.DELIVERY_ACK ? 'receiptTimestamp' : 'readTimestamp';
+                        ev.emit('message-receipt.update', ids.map(id => ({
+                            key: { ...key, id },
+                            receipt: {
+                                userJid: (0, WABinary_1.jidNormalizedUser)(attrs.participant),
+                                [updateKey]: +attrs.t
+                            }
+                        })));
+                    }
                 }
                 else {
                     ev.emit('messages.update', ids.map(id => ({

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -378,17 +378,19 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 					)
 				) {
 					if(isJidGroup(remoteJid)) {
-						const updateKey: keyof MessageUserReceipt = status === proto.WebMessageInfo.WebMessageInfoStatus.DELIVERY_ACK ? 'receiptTimestamp' : 'readTimestamp'
-						ev.emit(
-							'message-receipt.update',
-							ids.map(id => ({
-								key: { ...key, id },
-								receipt: {
-									userJid: jidNormalizedUser(attrs.participant),
-									[updateKey]: +attrs.t
-								}
-							}))
-						)
+						if(attrs.participant) {
+							const updateKey: keyof MessageUserReceipt = status === proto.WebMessageInfo.WebMessageInfoStatus.DELIVERY_ACK ? 'receiptTimestamp' : 'readTimestamp'
+							ev.emit(
+								'message-receipt.update',
+								ids.map(id => ({
+									key: { ...key, id },
+									receipt: {
+										userJid: jidNormalizedUser(attrs.participant),
+										[updateKey]: +attrs.t
+									}
+								}))
+							)
+						}
 					} else {
 						ev.emit(
 							'messages.update',


### PR DESCRIPTION
The error was encountered in @mwhitworth's setup and fixed in the latest version.
This PR cherrypicks that change