### PR TITLE
Do not set reason on fetch

### DIFF
--- a/lib/Socket/messages-send.js
+++ b/lib/Socket/messages-send.js
@@ -214,7 +214,7 @@ const makeMessagesSocket = (config) => {
                         attrs: {},
                         content: jidsRequiringFetch.map(jid => ({
                             tag: 'user',
-                            attrs: { jid, reason: 'identity' },
+                            attrs: { jid },
                         }))
                     }
                 ]

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -241,7 +241,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 						content: jidsRequiringFetch.map(
 							jid => ({
 								tag: 'user',
-								attrs: { jid, reason: 'identity' },
+								attrs: { jid },
 							})
 						)
 					}


### PR DESCRIPTION
Cherrypick of a fix. I haven't found any mention of an issue around this but this looks like a fairly harmless change and `assertSessions` is used in multiple places in the codebase