### PR TITLE
Set reaction sender correctly

### DIFF
--- a/lib/Utils/process-message.js
+++ b/lib/Utils/process-message.js
@@ -20,9 +20,19 @@ const cleanMessage = (message, meId) => {
     // if the message has a reaction, ensure fromMe & remoteJid are from our perspective
     if (content === null || content === void 0 ? void 0 : content.reactionMessage) {
         const msgKey = content.reactionMessage.key;
+        // if the reaction is from another user
+        // we've to correctly map the key to this user's perspective
         if (!message.key.fromMe) {
+            // if the sender believed the message being reacted to is not from them
+            // we've to correct the key to be from them, or some other participant
+            msgKey.fromMe = !msgKey.fromMe
+                ? (0, WABinary_1.areJidsSameUser)(msgKey.participant || msgKey.remoteJid, meId)
+                // if the message being reacted to, was from them
+                // fromMe automatically becomes false
+                : false;
+            // set the remoteJid to being the same as the chat the message came from
             msgKey.remoteJid = message.key.remoteJid;
-            msgKey.fromMe = (0, WABinary_1.areJidsSameUser)(msgKey.participant || msgKey.remoteJid, meId);
+            // set participant of the message
             msgKey.participant = msgKey.participant || message.key.participant;
         }
     }

--- a/lib/Utils/process-message.js
+++ b/lib/Utils/process-message.js
@@ -21,8 +21,8 @@ const cleanMessage = (message, meId) => {
     if (content === null || content === void 0 ? void 0 : content.reactionMessage) {
         const msgKey = content.reactionMessage.key;
         if (!message.key.fromMe) {
-            msgKey.fromMe = (0, WABinary_1.areJidsSameUser)(msgKey.participant || msgKey.remoteJid, meId);
             msgKey.remoteJid = message.key.remoteJid;
+            msgKey.fromMe = (0, WABinary_1.areJidsSameUser)(msgKey.participant || msgKey.remoteJid, meId);
             msgKey.participant = msgKey.participant || message.key.participant;
         }
     }

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -30,9 +30,19 @@ export const cleanMessage = (message: proto.IWebMessageInfo, meId: string) => {
 	// if the message has a reaction, ensure fromMe & remoteJid are from our perspective
 	if(content?.reactionMessage) {
 		const msgKey = content.reactionMessage.key!
+		// if the reaction is from another user
+		// we've to correctly map the key to this user's perspective
 		if(!message.key.fromMe) {
+			// if the sender believed the message being reacted to is not from them
+			// we've to correct the key to be from them, or some other participant
+			msgKey.fromMe = !msgKey.fromMe
+				? areJidsSameUser(msgKey.participant || msgKey.remoteJid!, meId)
+				// if the message being reacted to, was from them
+				// fromMe automatically becomes false
+				: false
+			// set the remoteJid to being the same as the chat the message came from
 			msgKey.remoteJid = message.key.remoteJid
-			msgKey.fromMe = areJidsSameUser(msgKey.participant || msgKey.remoteJid, meId)
+			// set participant of the message
 			msgKey.participant = msgKey.participant || message.key.participant
 		}
 	}

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -31,8 +31,8 @@ export const cleanMessage = (message: proto.IWebMessageInfo, meId: string) => {
 	if(content?.reactionMessage) {
 		const msgKey = content.reactionMessage.key!
 		if(!message.key.fromMe) {
-			msgKey.fromMe = areJidsSameUser(msgKey.participant || msgKey.remoteJid, meId)
 			msgKey.remoteJid = message.key.remoteJid
+			msgKey.fromMe = areJidsSameUser(msgKey.participant || msgKey.remoteJid, meId)
 			msgKey.participant = msgKey.participant || message.key.participant
 		}
 	}


### PR DESCRIPTION
Cherrypick of two fixes around setting the metadata correctly for a message reaction. It's in our best interest that message sender/receiver data is set correctly