### PR TITLE
Fix crash when hanging

### DIFF
--- a/lib/Socket/socket.js
+++ b/lib/Socket/socket.js
@@ -119,9 +119,13 @@ const makeSocket = ({ waWebSocketUrl, connectTimeoutMs, logger, agent, keepAlive
             node.attrs.id = generateMessageTag();
         }
         const msgId = node.attrs.id;
-        const wait = waitForMessage(msgId, timeoutMs);
+        let waitForMessageErr;
+        const wait = waitForMessage(msgId, timeoutMs).catch(err => waitForMessageErr = err);
         await sendNode(node);
         const result = await wait;
+        if (waitForMessageErr) {
+            throw waitForMessageErr;
+        }
         if ('tag' in result) {
             (0, WABinary_1.assertNodeErrorFree)(result);
         }

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -147,11 +147,15 @@ export const makeSocket = ({
 		}
 
 		const msgId = node.attrs.id
-		const wait = waitForMessage(msgId, timeoutMs)
+		let waitForMessageErr;
+		const wait = waitForMessage(msgId, timeoutMs).catch(err => waitForMessageErr = err);
 
 		await sendNode(node)
 
 		const result = await (wait as Promise<BinaryNode>)
+		if (waitForMessageErr) {
+			throw waitForMessageErr;
+		}
 		if('tag' in result) {
 			assertNodeErrorFree(result)
 		}


### PR DESCRIPTION
Related to the following crash https://sentry.io/organizations/tallarium/issues/3390701765/?project=6151145&statsPeriod=14d
Even if the promise is awaited later, an exception thrown within it will result in an unhandled rejection. We can throw the exception later as it will be caught later when `query` is called in `startKeepAliveRequest`, making the socket disconnect -> reconnect