### PR TITLE
Fix crash when ws has an operation in progress while closing

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -292,16 +292,18 @@ export const makeSocket = ({
 		clearInterval(keepAliveReq)
 		clearTimeout(qrTimer)
 
-		ws.removeAllListeners('close')
-		ws.removeAllListeners('error')
-		ws.removeAllListeners('open')
-		ws.removeAllListeners('message')
-
 		if(ws.readyState !== ws.CLOSED && ws.readyState !== ws.CLOSING) {
 			try {
 				ws.close()
 			} catch{ }
 		}
+
+		process.nextTick(() => {
+			ws.removeAllListeners('close')
+			ws.removeAllListeners('error')
+			ws.removeAllListeners('open')
+			ws.removeAllListeners('message')
+		});
 
 		ev.emit('connection.update', {
 			connection: 'close',


### PR DESCRIPTION
If the socket has an operation in progress, when closing, the error will be thrown on `process.nextTick`. Since we unregister the handlers, the error will propagate and crash the app, so we should also unregister the handlers on `process.nextTick`

Specific line that causes the issue: https://github.com/websockets/ws/blob/975382178f8a9355a5a564bb29cb1566889da9ba/lib/websocket.js#L1063

More information on this specific timing issue and how try-catch blocks miss it can be found here http://benno.id.au/blog/2011/08/08/nodejs-exceptions

To reproduce locally, the attached patch for the `ws` library can be used: [ws+8.8.1.zip](https://github.com/tallarium/Baileys/files/9558694/ws%2B8.8.1.zip)
