### PR TITLE
TL-2140 Handle timeout crash prekey upload

### DIFF
--- a/lib/Socket/socket.js
+++ b/lib/Socket/socket.js
@@ -572,8 +572,13 @@ const makeSocket = (config) => {
     });
     // login complete
     ws.on('CB:success', async () => {
-        await uploadPreKeysToServerIfRequired();
-        await sendPassiveIq('active');
+        try {
+            await uploadPreKeysToServerIfRequired();
+            await sendPassiveIq('active');
+        }
+        catch (err) {
+            logger.warn({ err }, 'failed to send initial passive iq');
+        }
         logger.info('opened connection to WA');
         clearTimeout(qrTimer); // will never happen in all likelyhood -- but just in case WA sends success on first try
         ev.emit('connection.update', { connection: 'open' });

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -721,8 +721,12 @@ export const makeSocket = (config: SocketConfig) => {
 	})
 	// login complete
 	ws.on('CB:success', async() => {
-		await uploadPreKeysToServerIfRequired()
-		await sendPassiveIq('active')
+		try {
+			await uploadPreKeysToServerIfRequired()
+			await sendPassiveIq('active')
+		} catch (err) {
+			logger.warn({ err }, 'failed to send initial passive iq')
+		}
 
 		logger.info('opened connection to WA')
 		clearTimeout(qrTimer) // will never happen in all likelyhood -- but just in case WA sends success on first try


### PR DESCRIPTION
https://tallarium.atlassian.net/browse/TL-2140

Change taken from https://github.com/WhiskeySockets/Baileys/pull/1627

I think the second part of the change of returning undefined when the `waitForMessage` is currently incompatible with our code since `query` would just return `undefined` and in places like:
https://github.com/tallarium/Baileys/blob/3453f204fe4499a04007c93fba051bf55e8f7303/src/Socket/messages-send.ts#L196 -> https://github.com/tallarium/Baileys/blob/34f2095263a15dd93679f6dd804b00806a28e716/src/Utils/signal.ts#L240 we would run into a "property not in undefined" error

It can be worth adding this in but we haven't seen this issue happen from any other stack aside from the startup upload prekeys or from the message receive handler https://my.na-01.cloud.solarwinds.com/226133060723345408/logs?q=%22unhandled%20rejection%22%20-%22uploadPreKeysToServerIfRequired%22&selected=1906780523179761668