### PR TITLE
TL-2486 Fix libsignal version to version from yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@hapi/boom": "^9.1.3",
     "async-mutex": "^0.5.0",
     "axios": "^1.6.0",
-    "libsignal": "git+https://github.com/whiskeysockets/libsignal-node",
+    "libsignal": "git+https://github.com/whiskeysockets/libsignal-node#4d08331a",
     "music-metadata": "^11.7.0",
     "pino": "^9.6",
     "protobufjs": "^7.2.4",


### PR DESCRIPTION
They have added typing to the more recent libsignal but it results in compilation errors so fixing to the version in the yarn.lock file until those are resolved